### PR TITLE
Introduce FastAPI backend server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # entoit
-LLM chatbot for English to Italian translation, in FastAPI + TypeScript
+LLM chatbot using LangChain for English to Italian translation. Full-stack web app in
+FastAPI and TypeScript.
 
 ## Prerequisites
 
@@ -7,36 +8,7 @@ Python 3.10, Node.js 18, npm >= 9.5
 
 ## Development Tools
 
-To set up the Python development environment,
-
-1. Create a Python virtual environment called `.entoit` using:
-
-    ```
-    python3 -m venv --upgrade-deps --clear --prompt entoit .entoit
-    ```
-
-    This command will replace any existing `.entoit` virtual environment.
-
-2. Activate the `.entoit` environment by running
-
-    ```shell
-    source .entoit/bin/activate
-    ```
-
-### The `ci` module
-
-The `ci` module offers a Python CLI tool for handling day-to-day development tasks,
-including setting up a development environment, applying code linting and formatting,
-and other development and deployment tasks. To install the dependencies for the `ci`
-module, run:
-
-```
-python -m pip install -r ci/requirements.txt
-```
-
-The `ci` module defines functions that can be called as CLI commands. For instance,
-to apply code formatting, run:
-
-```
-python -m ci format
-```
+The [`ci` module](ci/) provides a Python CLI tool for handling day-to-day development
+tasks, including setting up a development environment, applying code linting and
+formatting, and other development and deployment tasks. Usage instructions and the full
+list of `ci` commands can be found in the `ci` module [README](ci/README.md).

--- a/backend/server/app.py
+++ b/backend/server/app.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, FastAPI
+
+router = APIRouter(prefix="/api/v1")
+
+
+def create_app() -> FastAPI:
+    """
+    Create the FastAPI backend server application.
+    """
+    app = FastAPI()
+    app.include_router(router)
+
+    return app
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("app:create_app", factory=True, reload=True)

--- a/backend/server/endpoints.py
+++ b/backend/server/endpoints.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from app import router
+
+# Type alias for a JSON object
+JSON = dict[str, Any]
+
+
+@router.post("/ask_llm")
+def get_llm_response(query: JSON) -> JSON:
+    """
+    Call OpenAI API with the user prompt and return the response.
+    """
+    response = "Hello, World!"
+    return {"response": response}

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,40 @@
+# The `ci` module
+
+The `ci` module offers a Python CLI tool for handling day-to-day development tasks,
+including setting up a development environment, applying code linting and formatting,
+and other development and deployment tasks. 
+
+Running the `ci/install.sh` shell script will create a Python virtual environment
+called `entoit` and install `ci` and project dependencies. To activate the `entoit`
+venv, run:
+
+    ```shell
+    source .entoit/bin/activate
+    ```
+
+The `ci` module defines functions that can be called as CLI commands from inside
+`entoit`.
+
+## Apply code formatting
+
+```
+python -m ci format
+```
+
+## Apply code linting
+
+```
+python -m ci lint
+```
+
+## Generate `requirements.txt` from `pyproject.toml`
+
+```
+python -m ci update-requirements
+```
+
+## Start the FastAPI backend server
+
+```
+python -m ci backend
+```

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -86,5 +86,12 @@ def format():
         click.secho("Done.", fg="green")
 
 
+@cli.command("backend")
+def start_backend():
+    """Start the FastAPI backend server."""
+
+    sp.run(["uvicorn", "backend.server.app:create_app", "--factory", "--reload"])
+
+
 if __name__ == "__main__":
     cli()

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+cd `dirname $0`
+
+python3 -m venv --upgrade-deps --clear --prompt entoit .entoit
+source .entoit/bin/activate
+python -m pip install -r ci/requirements.txt
+python -m pip install -r backend/requirements.txt
+deactivate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-extend-exclude = ".entoit"
+extend-exclude = "/.entoit/"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This PR introduces a FastAPI backend server with a placeholder POST endpoint. 

Additionally:
* The `ci` CLI tool has been updated to include a new command for starting the backend server,
* The `ci` module now has a dedicated `README.md` with the full list of available commands, and
* A `install.sh` shell script has been added as a helper for quick installation of the Python dev env.